### PR TITLE
fix: adding chartset to the response

### DIFF
--- a/response_test.go
+++ b/response_test.go
@@ -67,7 +67,7 @@ func Test_SendResponse(t *testing.T) {
 			}
 
 			assert.Equal(t, tt.expectedCode, w.Code)
-			assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
+			assert.Equal(t, "application/json; charset=utf-8", w.Header().Get("Content-Type"))
 			assert.JSONEq(t, tt.expectedJSON, w.Body.String())
 		})
 	}


### PR DESCRIPTION
This PR adds the chatset as utf-8 to all responses.

Closes #5 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Updated the `Content-Type` header in HTTP responses to include character encoding, improving compatibility for clients interpreting JSON data.
	- Enhanced error handling to provide structured error responses in case of JSON encoding errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->